### PR TITLE
chore: re-enable lint during build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,6 @@
 module.exports = {
+  root: true,
+  ignorePatterns: ['.next/'],
   extends: ['next', 'next/core-web-vitals'],
   overrides: [
     {

--- a/app/cloudinary-diagnostics/page.tsx
+++ b/app/cloudinary-diagnostics/page.tsx
@@ -146,7 +146,7 @@ export default function DiagnosticsPage() {
 
           <ol className="list-decimal ml-6 space-y-2">
             <li>
-              Check if you've run{' '}
+              Check if you&apos;ve run{' '}
               <code className="bg-gray-100 px-1">npm run upload-images</code> to
               upload your images to Cloudinary
             </li>

--- a/app/diagnostics/page.tsx
+++ b/app/diagnostics/page.tsx
@@ -101,7 +101,9 @@ export default function DiagnosticPage() {
           </li>
           <li>Try with and without folder paths</li>
           <li>Confirm your images are publicly accessible</li>
-          <li>Try a sample image (like 'sample') to verify basic access</li>
+          <li>
+            Try a sample image (like &apos;sample&apos;) to verify basic access
+          </li>
         </ul>
       </div>
     </div>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,9 +1,9 @@
-import type { Metadata } from "next";
+import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "404",
-  description: "Error 404",
-};
+  title: '404',
+  description: 'Error 404',
+}
 
 export default function NotFound() {
   return (
@@ -12,8 +12,8 @@ export default function NotFound() {
         404 - Page not found
       </h1>
       <p className="mb-4">
-        Oops! The page you're looking for doesn't seem to exist.
+        Oops! The page you&apos;re looking for doesn&apos;t seem to exist.
       </p>
     </section>
-  );
+  )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -6,9 +6,6 @@ const nextConfig = {
     unoptimized: true, // Use this to bypass Next.js image optimization
     domains: ['res.cloudinary.com'],
   },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- re-enable linting during next build
- add eslint root + ignore .next to avoid parent config bleed
- escape unescaped entities to satisfy react/no-unescaped-entities

## Test Plan
- corepack pnpm run build