### PR TITLE
chore: add vercel ignore rules

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+.git/
+.vercel/
+.worktrees/
+.crush/
+.next/
+node_modules/
+*.log


### PR DESCRIPTION
## Summary
- add .vercelignore to exclude worktrees, .crush, .next, and node_modules from deploy uploads

## Test Plan
- vercel deploy (post-merge)